### PR TITLE
fix(a11y): remove target size overrides from inline legal link

### DIFF
--- a/static/css/footer.css
+++ b/static/css/footer.css
@@ -158,13 +158,6 @@
 .footer-legal a {
     color: #212129;
     text-decoration: underline;
-    /* WCAG 2.5.5: ensure 44x44px minimum target size */
-    display: inline-block;
-    min-width: 44px;
-    min-height: 44px;
-    line-height: 44px;
-    margin-block: -14px;
-    text-align: center;
 }
 
 .sr-only {


### PR DESCRIPTION
## Summary
- Remove `display: inline-block`, `min-width`, `min-height`, and `line-height` overrides from `.footer-legal a` that were breaking natural text wrapping on mobile
- Inline links within sentences are exempt from WCAG 2.5.5/2.5.8 target size requirements per the spec's inline exception

Ref #8

## Test plan
- [x] Verify legal text link wraps naturally within the paragraph on mobile viewports
- [x] Confirm no layout regression on desktop
- [x] WCAG inspector: inline link exemption applies, no action needed on target size