### PR TITLE
feat(cms): add secret preview URLs for unpublished pages and posts

### DIFF
--- a/cms/migrations/0010_add_preview_token.py
+++ b/cms/migrations/0010_add_preview_token.py
@@ -1,0 +1,60 @@
+import uuid
+
+from django.db import migrations, models
+
+
+def populate_preview_tokens(apps, schema_editor):
+    Page = apps.get_model("cms", "Page")
+    Post = apps.get_model("cms", "Post")
+    for obj in Page.objects.filter(preview_token=None):
+        obj.preview_token = uuid.uuid4()
+        obj.save(update_fields=["preview_token"])
+    for obj in Post.objects.filter(preview_token=None):
+        obj.preview_token = uuid.uuid4()
+        obj.save(update_fields=["preview_token"])
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("cms", "0009_merge_0007_add_post_byline_0008_seed_footer_defaults"),
+    ]
+
+    operations = [
+        # Step 1: add nullable (so existing rows don't need a value yet)
+        migrations.AddField(
+            model_name="page",
+            name="preview_token",
+            field=models.UUIDField(null=True, unique=False),
+        ),
+        migrations.AddField(
+            model_name="post",
+            name="preview_token",
+            field=models.UUIDField(null=True, unique=False),
+        ),
+        # Step 2: populate tokens for any existing rows
+        migrations.RunPython(
+            populate_preview_tokens, migrations.RunPython.noop
+        ),
+        # Step 3: make non-nullable and unique
+        migrations.AlterField(
+            model_name="page",
+            name="preview_token",
+            field=models.UUIDField(
+                default=uuid.uuid4,
+                editable=False,
+                unique=True,
+                help_text="Secret token for shareable preview URL",
+            ),
+        ),
+        migrations.AlterField(
+            model_name="post",
+            name="preview_token",
+            field=models.UUIDField(
+                default=uuid.uuid4,
+                editable=False,
+                unique=True,
+                help_text="Secret token for shareable preview URL",
+            ),
+        ),
+    ]

--- a/cms/models.py
+++ b/cms/models.py
@@ -2,6 +2,8 @@
 CMS models for translatable rich-text content pages and snippets.
 """
 
+import uuid
+
 import bleach
 from django.core.cache import cache
 from django.db import models
@@ -94,6 +96,12 @@ class Page(models.Model):
         default=False,
         help_text="Only published pages are visible on the site",
     )
+    preview_token = models.UUIDField(
+        default=uuid.uuid4,
+        editable=False,
+        unique=True,
+        help_text="Secret token for shareable preview URL",
+    )
     sort_order = models.IntegerField(
         default=0,
         help_text="Lower numbers appear first",
@@ -153,6 +161,12 @@ class Post(models.Model):
     is_published = models.BooleanField(
         default=False,
         help_text="Only published posts are visible on the site",
+    )
+    preview_token = models.UUIDField(
+        default=uuid.uuid4,
+        editable=False,
+        unique=True,
+        help_text="Secret token for shareable preview URL",
     )
     published_at = models.DateTimeField(
         null=True,

--- a/cms/templates/cms/manager/page_form.html
+++ b/cms/templates/cms/manager/page_form.html
@@ -53,11 +53,25 @@
                     <div class="mgr-help">Only published pages appear on the site.</div>
                 </div>
 
-                <div class="mgr-field" style="margin-bottom:0;">
+                <div class="mgr-field">
                     <label class="mgr-label" for="{{ form.sort_order.id_for_label }}">Sort Order</label>
                     {{ form.sort_order }}
                     <div class="mgr-help">Lower numbers appear first.</div>
                 </div>
+
+                {% if object.preview_token %}
+                <div class="mgr-field" style="margin-bottom:0;">
+                    <div class="mgr-label">Preview link</div>
+                    <button type="button"
+                            class="btn-mgr-secondary"
+                            style="width:100%; justify-content:center;"
+                            data-preview-url="{{ request.scheme }}://{{ request.get_host }}{% url 'cms:page-preview' object.preview_token %}"
+                            onclick="navigator.clipboard.writeText(this.dataset.previewUrl).then(() => { this.textContent = '✓ Copied'; setTimeout(() => { this.innerHTML = '<i class=\'bi bi-link-45deg\'></i> Copy preview link'; }, 2000); })">
+                        <i class="bi bi-link-45deg"></i> Copy preview link
+                    </button>
+                    <div class="mgr-help">Share this link to let others view the page before publishing.</div>
+                </div>
+                {% endif %}
             </div>
 
             <div class="mgr-form-card">

--- a/cms/templates/cms/manager/post_form.html
+++ b/cms/templates/cms/manager/post_form.html
@@ -67,12 +67,26 @@
                     <div class="mgr-help">Only published posts appear on the site.</div>
                 </div>
 
-                <div class="mgr-field" style="margin-bottom:0;">
+                <div class="mgr-field">
                     <label class="mgr-label" for="{{ form.published_at.id_for_label }}">Publish Date</label>
                     {{ form.published_at }}
                     <div class="mgr-help">Used for ordering in listings.</div>
                     {% if form.published_at.errors %}<div class="mgr-error">{{ form.published_at.errors.0 }}</div>{% endif %}
                 </div>
+
+                {% if object.preview_token %}
+                <div class="mgr-field" style="margin-bottom:0;">
+                    <div class="mgr-label">Preview link</div>
+                    <button type="button"
+                            class="btn-mgr-secondary"
+                            style="width:100%; justify-content:center;"
+                            data-preview-url="{{ request.scheme }}://{{ request.get_host }}{% url 'cms:post-preview' object.preview_token %}"
+                            onclick="navigator.clipboard.writeText(this.dataset.previewUrl).then(() => { this.textContent = '✓ Copied'; setTimeout(() => { this.innerHTML = '<i class=\'bi bi-link-45deg\'></i> Copy preview link'; }, 2000); })">
+                        <i class="bi bi-link-45deg"></i> Copy preview link
+                    </button>
+                    <div class="mgr-help">Share this link to let others view the post before publishing.</div>
+                </div>
+                {% endif %}
             </div>
 
             <div class="mgr-form-card">

--- a/cms/templates/news_detail.html
+++ b/cms/templates/news_detail.html
@@ -14,6 +14,12 @@
 
 {% block content %}
 
+{% if is_preview %}
+<div class="preview-banner" role="alert">
+    <strong>Preview</strong> — this post is not yet published and is only visible via this link.
+</div>
+{% endif %}
+
 <!-- Article header -->
 <header class="news-detail-header">
     <!-- Concentric arcs decoration -->

--- a/cms/templates/page_detail.html
+++ b/cms/templates/page_detail.html
@@ -1,0 +1,47 @@
+{% extends "base.html" %}
+
+{% block title %}{{ page.title }} — Open Journals Collective{% endblock %}
+
+{% block extra_head %}
+    {% if page.meta_description %}
+    <meta name="description" content="{{ page.meta_description }}">
+    {% endif %}
+{% endblock %}
+
+{% block extra_css %}
+    <link rel="stylesheet" href="/static/css/news.css">
+{% endblock %}
+
+{% block content %}
+
+{% if is_preview %}
+<div class="preview-banner" role="alert">
+    <strong>Preview</strong> — this page is not yet published and is only visible via this link.
+</div>
+{% endif %}
+
+<header class="news-detail-header">
+    <svg class="news-detail-header__arcs" viewBox="0 0 580 580" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" overflow="visible">
+        <circle cx="290" cy="290" r="100" fill="none" stroke="#212129" stroke-width="48" opacity="0.08"/>
+        <circle cx="290" cy="290" r="195" fill="none" stroke="#212129" stroke-width="48" opacity="0.08"/>
+        <circle cx="290" cy="290" r="290" fill="none" stroke="#212129" stroke-width="48" opacity="0.08"/>
+        <circle cx="290" cy="290" r="385" fill="none" stroke="#212129" stroke-width="48" opacity="0.08"/>
+    </svg>
+    <div class="container">
+        <h1 id="page-title" class="news-detail-header__title spectral-extrabold">
+            {{ page.title }}
+        </h1>
+    </div>
+</header>
+
+{% if page.body %}
+<article class="news-detail-body" aria-labelledby="page-title">
+    <div class="container">
+        <div class="news-detail-body__inner">
+            {{ page.body|safe }}
+        </div>
+    </div>
+</article>
+{% endif %}
+
+{% endblock %}

--- a/cms/urls.py
+++ b/cms/urls.py
@@ -9,7 +9,9 @@ from cms.views import (
     index_view,
     news_detail_view,
     news_index_view,
+    page_preview_view,
     partial_view,
+    post_preview_view,
 )
 
 app_name = "cms"
@@ -24,4 +26,6 @@ urlpatterns = [
     ),
     path("news/", news_index_view, name="news-index"),
     path("news/<slug:slug>/", news_detail_view, name="news-detail"),
+    path("preview/post/<uuid:token>/", post_preview_view, name="post-preview"),
+    path("preview/page/<uuid:token>/", page_preview_view, name="page-preview"),
 ]

--- a/cms/views.py
+++ b/cms/views.py
@@ -5,7 +5,7 @@ CMS views for static content pages.
 from django.core.paginator import Paginator
 from django.shortcuts import get_object_or_404, render
 
-from .models import LandingPageSettings, Post
+from .models import LandingPageSettings, Page, Post
 
 
 def index_view(request):
@@ -31,3 +31,17 @@ def news_index_view(request):
 def news_detail_view(request, slug):
     post = get_object_or_404(Post, slug=slug, is_published=True)
     return render(request, "news_detail.html", {"post": post})
+
+
+def post_preview_view(request, token):
+    post = get_object_or_404(Post, preview_token=token)
+    return render(
+        request, "news_detail.html", {"post": post, "is_preview": True}
+    )
+
+
+def page_preview_view(request, token):
+    page = get_object_or_404(Page, preview_token=token)
+    return render(
+        request, "page_detail.html", {"page": page, "is_preview": True}
+    )

--- a/static/css/news.css
+++ b/static/css/news.css
@@ -14,6 +14,16 @@
     --news-on-yellow:     #38383f; /* 7.94:1 on #FFDE59 — passes AAA */
 }
 
+/* --- Preview banner --- */
+.preview-banner {
+    background: #fff3cd;
+    color: #7d4e00;
+    border-bottom: 2px solid #FFDE59;
+    padding: 12px 0;
+    font-size: 14px;
+    text-align: center;
+}
+
 /* --- Page Hero --- */
 .news-hero {
     position: relative;


### PR DESCRIPTION
- Add preview_token UUIDField to Page and Post models
- Migration 0010 populates tokens for existing rows then adds unique constraint
- Add /preview/post/<uuid>/ and /preview/page/<uuid>/ public routes (no auth required)
- Render content normally but show a preview banner when accessed via token
- Add 'Copy preview link' button to page and post edit forms (edit only, not create)
- Create page_detail.html template (pages had no public template previously)