### PR TITLE
Fix header logo not linking to homepage

### DIFF
--- a/cms/templates/includes/header.html
+++ b/cms/templates/includes/header.html
@@ -3,9 +3,11 @@
     <div class="container">
         <div class="landing-header-inner">
             <div class="landing-header-logo">
-                <img src="/static/img/OJC-logo.svg" class="mini-logo"
-                     alt="Open Journals Collective logo">
-                <span class="landing-header-logo-text">{{ header.logo_line_1 }}<br>{{ header.logo_line_2 }}<br>{{ header.logo_line_3 }}</span>
+                <a href="/" class="landing-header-logo-link">
+                    <img src="/static/img/OJC-logo.svg" class="mini-logo"
+                         alt="Open Journals Collective logo">
+                    <span class="landing-header-logo-text">{{ header.logo_line_1 }}<br>{{ header.logo_line_2 }}<br>{{ header.logo_line_3 }}</span>
+                </a>
             </div>
             <nav class="landing-nav" id="landing-nav">
                 {% for item in header.get_menu_items %}
@@ -45,14 +47,16 @@
 <nav class="fullscreen-nav" id="fullscreen-nav" aria-label="Mobile navigation" aria-hidden="true">
     <div class="container">
         <div class="row">
-            <div class="col-2">
+            <a href="/" class="mobile-header-logo-link col-2">
                 <img src="/static/img/ojc-nav-logo.svg" class="mini-logo"
                      alt="Open Journals Collective">
-            </div>
+            </a>
             <div class="logo-text col-8 spectral-bold">
-                <span class="site-header-text">
-                    {{ header.logo_line_1 }} {{ header.logo_line_2 }} {{ header.logo_line_3 }}
-                </span>
+                <a href="/" class="mobile-header-logo-link">
+                    <span class="site-header-text">
+                        {{ header.logo_line_1 }} {{ header.logo_line_2 }} {{ header.logo_line_3 }}
+                    </span>
+                </a>
             </div>
             <button class="close-icon col-1" id="close-nav" aria-label="Close menu" type="button">&times;</button>
         </div>

--- a/cms/tests/test_header.py
+++ b/cms/tests/test_header.py
@@ -710,6 +710,18 @@ class HeaderTemplateTests(TestCase):
         self.assertIn("mobile-nav-submenu", content)
         self.assertIn("nav-sub-link", content)
 
+    def test_desktop_logo_links_to_homepage(self):
+        response = self.client.get(reverse("cms:index"))
+        content = response.content.decode()
+        self.assertIn("landing-header-logo-link", content)
+        self.assertIn('<a href="/" class="landing-header-logo-link">', content)
+
+    def test_mobile_logo_links_to_homepage(self):
+        response = self.client.get(reverse("cms:index"))
+        content = response.content.decode()
+        self.assertIn("mobile-header-logo-link", content)
+        self.assertIn('<a href="/" class="mobile-header-logo-link">', content)
+
     def test_header_hides_mobile_sub_items_when_disabled(self):
         self.header.show_mobile_sub_items = False
         self.header.save()

--- a/static/css/header.css
+++ b/static/css/header.css
@@ -30,6 +30,19 @@
     height: 44px;
 }
 
+.landing-header-logo-link {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    color: inherit;
+    text-decoration: none;
+}
+
+.mobile-header-logo-link {
+    color: inherit;
+    text-decoration: none;
+}
+
 .landing-header-logo-text {
     font-family: 'Spectral', serif;
     font-weight: 700;


### PR DESCRIPTION
## Summary

- Wraps the OJC logo and text in both the desktop and mobile headers with `<a href="/">` tags so clicking the logo navigates to the homepage
- Adds CSS rules to preserve the existing visual appearance (no text decoration, inherited colors, flex layout)
- Adds two tests verifying the logo links are present in the rendered HTML

## Test plan

- [x] All 479 tests pass
- [x] Pre-commit hooks pass
- [x] Visual verification via Puppeteer screenshot confirms no styling regressions

Ref #33