### PR TITLE
Fix HTML escaping in Our Model preset and harden related blocks

### DIFF
--- a/cms/forms.py
+++ b/cms/forms.py
@@ -907,8 +907,9 @@ class WideHeaderCirclesBlockForm(forms.ModelForm):
         ]
         widgets = {
             "heading": forms.TextInput(attrs={"class": "mgr-input"}),
-            "sub_heading": forms.Textarea(
-                attrs={"class": "mgr-textarea", "rows": 3}
+            "sub_heading": TinyMCE(
+                attrs={"aria-label": "Hero sub-heading"},
+                mce_attrs=_RESTRICTED_TINYMCE,
             ),
             "bg_color": forms.TextInput(attrs=_COLOR_ATTRS),
             "text_color": forms.TextInput(attrs=_COLOR_ATTRS),
@@ -1015,8 +1016,9 @@ class ContactFormBlockForm(forms.ModelForm):
         model = ContactFormBlock
         fields = ["intro_text", "from_email", "bg_color", "text_color"]
         widgets = {
-            "intro_text": forms.Textarea(
-                attrs={"class": "mgr-textarea", "rows": 3}
+            "intro_text": TinyMCE(
+                attrs={"aria-label": "Intro text"},
+                mce_attrs=_RESTRICTED_TINYMCE,
             ),
             "from_email": forms.EmailInput(attrs={"class": "mgr-input"}),
             "bg_color": forms.TextInput(attrs=_COLOR_ATTRS),
@@ -1126,8 +1128,9 @@ class FeatureCardsBlockForm(forms.ModelForm):
         widgets = {
             # Card 1
             "card_1_title": forms.TextInput(attrs={"class": "mgr-input"}),
-            "card_1_text": forms.Textarea(
-                attrs={"class": "mgr-textarea", "rows": 4}
+            "card_1_text": TinyMCE(
+                attrs={"aria-label": "Card 1 text"},
+                mce_attrs=_RESTRICTED_TINYMCE,
             ),
             "card_1_image_alt": forms.TextInput(attrs={"class": "mgr-input"}),
             "card_1_number": forms.TextInput(
@@ -1143,8 +1146,9 @@ class FeatureCardsBlockForm(forms.ModelForm):
             "card_1_bg_color": forms.TextInput(attrs=_COLOR_ATTRS),
             # Card 2
             "card_2_title": forms.TextInput(attrs={"class": "mgr-input"}),
-            "card_2_text": forms.Textarea(
-                attrs={"class": "mgr-textarea", "rows": 4}
+            "card_2_text": TinyMCE(
+                attrs={"aria-label": "Card 2 text"},
+                mce_attrs=_RESTRICTED_TINYMCE,
             ),
             "card_2_image_alt": forms.TextInput(attrs={"class": "mgr-input"}),
             "card_2_number": forms.TextInput(
@@ -1160,8 +1164,9 @@ class FeatureCardsBlockForm(forms.ModelForm):
             "card_2_bg_color": forms.TextInput(attrs=_COLOR_ATTRS),
             # Card 3
             "card_3_title": forms.TextInput(attrs={"class": "mgr-input"}),
-            "card_3_text": forms.Textarea(
-                attrs={"class": "mgr-textarea", "rows": 4}
+            "card_3_text": TinyMCE(
+                attrs={"aria-label": "Card 3 text"},
+                mce_attrs=_RESTRICTED_TINYMCE,
             ),
             "card_3_image_alt": forms.TextInput(attrs={"class": "mgr-input"}),
             "card_3_number": forms.TextInput(

--- a/cms/forms.py
+++ b/cms/forms.py
@@ -276,6 +276,17 @@ _RESTRICTED_TINYMCE = {
 }
 
 
+_INLINE_TINYMCE = {
+    "height": 120,
+    "menubar": False,
+    "plugins": "",
+    "toolbar": "bold italic underline | superscript subscript | removeformat",
+    "forced_root_block": "",
+    "valid_elements": "strong/b,em/i,u,br,sub,sup,span,a[href|title|rel|target]",
+    "invalid_elements": "p,div,h1,h2,h3,h4,h5,h6,ul,ol,li,blockquote,table,script,iframe,object,embed,form,input",
+}
+
+
 _MANIFESTO_TINYMCE = {
     "height": 200,
     "menubar": False,
@@ -755,11 +766,13 @@ class RevenueDistributionBlockForm(forms.ModelForm):
         ]
         widgets = {
             "heading": forms.TextInput(attrs={"class": "mgr-input"}),
-            "description": forms.Textarea(
-                attrs={"class": "mgr-textarea", "rows": 3}
+            "description": TinyMCE(
+                attrs={"aria-label": "Section description"},
+                mce_attrs=_RESTRICTED_TINYMCE,
             ),
-            "callout": forms.Textarea(
-                attrs={"class": "mgr-textarea", "rows": 3}
+            "callout": TinyMCE(
+                attrs={"aria-label": "Callout"},
+                mce_attrs=_RESTRICTED_TINYMCE,
             ),
             "bg_color": forms.TextInput(attrs=_COLOR_ATTRS),
             "text_color": forms.TextInput(attrs=_COLOR_ATTRS),
@@ -801,8 +814,9 @@ class RevenuePackageTableForm(forms.ModelForm):
         ]
         widgets = {
             "title": forms.TextInput(attrs={"class": "mgr-input"}),
-            "description": forms.Textarea(
-                attrs={"class": "mgr-textarea", "rows": 2}
+            "description": TinyMCE(
+                attrs={"aria-label": "Package description"},
+                mce_attrs=_INLINE_TINYMCE,
             ),
             "colour_preset": forms.Select(attrs={"class": "mgr-input"}),
             "custom_header_bg": forms.TextInput(

--- a/cms/forms.py
+++ b/cms/forms.py
@@ -682,8 +682,9 @@ class OJCModelBlockForm(forms.ModelForm):
                 attrs={"aria-label": "OJC Model body"},
                 mce_attrs=_RESTRICTED_TINYMCE,
             ),
-            "collections_label": forms.Textarea(
-                attrs={"class": "mgr-textarea", "rows": 2}
+            "collections_label": TinyMCE(
+                attrs={"aria-label": "Collections label"},
+                mce_attrs=_RESTRICTED_TINYMCE,
             ),
             "collection_1_number": forms.TextInput(
                 attrs={"class": "mgr-input", "style": "max-width:80px;"}

--- a/cms/migrations/0082_normalize_revenue_descriptions.py
+++ b/cms/migrations/0082_normalize_revenue_descriptions.py
@@ -1,0 +1,107 @@
+"""
+Normalise stored HTML in RevenueDistributionBlock and RevenuePackageTable so
+existing rows render correctly under the new template/sanitiser conventions:
+
+* RevenueDistributionBlock.description / .callout: keep block-level HTML and
+  pass through bleach with the standard allow-list, wrapping plain-text values
+  in ``<p>`` so the section still renders as a paragraph after the template
+  drops its outer ``<p>`` wrapper.
+* RevenuePackageTable.description: rendered inside ``<th>`` where block tags
+  are invalid, so strip everything down to inline-only HTML (``<p>foo</p>``
+  becomes ``foo``).
+"""
+
+import re
+
+import bleach
+from django.db import migrations
+
+_BLOCK_ALLOWED_TAGS = [
+    "a", "abbr", "acronym", "b", "blockquote", "br", "code", "del",
+    "em", "h1", "h2", "h3", "h4", "h5", "h6", "hr", "i", "img", "li",
+    "ol", "p", "pre", "s", "span", "strong", "sub", "sup", "table",
+    "tbody", "td", "th", "thead", "tr", "u", "ul",
+]
+_INLINE_ALLOWED_TAGS = [
+    "a", "abbr", "b", "br", "em", "i", "s", "span", "strong", "sub",
+    "sup", "u",
+]
+_ALLOWED_ATTRS = {
+    "a": ["href", "title", "rel", "target"],
+    "abbr": ["title"],
+    "acronym": ["title"],
+    "img": ["src", "alt", "width", "height", "class"],
+    "td": ["colspan", "rowspan"],
+    "th": ["colspan", "rowspan", "scope"],
+    "span": ["class"],
+}
+
+_BLOCK_TAG_RE = re.compile(
+    r"<\s*(p|div|h[1-6]|ul|ol|li|blockquote|table|pre)\b",
+    re.IGNORECASE,
+)
+
+
+def _normalise_block_text(value):
+    if not value:
+        return value
+    cleaned = bleach.clean(
+        value,
+        tags=_BLOCK_ALLOWED_TAGS,
+        attributes=_ALLOWED_ATTRS,
+        strip=True,
+    )
+    if not _BLOCK_TAG_RE.search(cleaned):
+        cleaned = f"<p>{cleaned.strip()}</p>"
+    return cleaned
+
+
+def _normalise_inline_text(value):
+    if not value:
+        return value
+    return bleach.clean(
+        value,
+        tags=_INLINE_ALLOWED_TAGS,
+        attributes=_ALLOWED_ATTRS,
+        strip=True,
+    ).strip()
+
+
+def forwards(apps, schema_editor):
+    RevenueDistributionBlock = apps.get_model(
+        "cms", "RevenueDistributionBlock"
+    )
+    RevenuePackageTable = apps.get_model("cms", "RevenuePackageTable")
+
+    for block in RevenueDistributionBlock.objects.all():
+        new_description = _normalise_block_text(block.description)
+        new_callout = _normalise_block_text(block.callout)
+        if (
+            new_description != block.description
+            or new_callout != block.callout
+        ):
+            block.description = new_description
+            block.callout = new_callout
+            block.save(update_fields=["description", "callout"])
+
+    for table in RevenuePackageTable.objects.all():
+        new_description = _normalise_inline_text(table.description)
+        if new_description != table.description:
+            table.description = new_description
+            table.save(update_fields=["description"])
+
+
+def reverse(apps, schema_editor):
+    # Stripping HTML is not safely reversible; leave normalised content in place.
+    pass
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("cms", "0081_remove_landingpagesettings"),
+    ]
+
+    operations = [
+        migrations.RunPython(forwards, reverse),
+    ]

--- a/cms/migrations/0082_normalize_revenue_descriptions.py
+++ b/cms/migrations/0082_normalize_revenue_descriptions.py
@@ -1,11 +1,11 @@
 """
-Normalise stored HTML in RevenueDistributionBlock and RevenuePackageTable so
-existing rows render correctly under the new template/sanitiser conventions:
+Normalise stored HTML in revenue distribution and OJC model blocks so existing
+rows render correctly under the new template/sanitiser conventions:
 
-* RevenueDistributionBlock.description / .callout: keep block-level HTML and
-  pass through bleach with the standard allow-list, wrapping plain-text values
-  in ``<p>`` so the section still renders as a paragraph after the template
-  drops its outer ``<p>`` wrapper.
+* RevenueDistributionBlock.description / .callout and OJCModelBlock.collections_label:
+  keep block-level HTML and pass through bleach with the standard allow-list,
+  wrapping plain-text values in ``<p>`` so the section still renders as a
+  paragraph after the template drops its outer ``<p>`` wrapper.
 * RevenuePackageTable.description: rendered inside ``<th>`` where block tags
   are invalid, so strip everything down to inline-only HTML (``<p>foo</p>``
   becomes ``foo``).
@@ -72,6 +72,7 @@ def forwards(apps, schema_editor):
         "cms", "RevenueDistributionBlock"
     )
     RevenuePackageTable = apps.get_model("cms", "RevenuePackageTable")
+    OJCModelBlock = apps.get_model("cms", "OJCModelBlock")
 
     for block in RevenueDistributionBlock.objects.all():
         new_description = _normalise_block_text(block.description)
@@ -89,6 +90,12 @@ def forwards(apps, schema_editor):
         if new_description != table.description:
             table.description = new_description
             table.save(update_fields=["description"])
+
+    for block in OJCModelBlock.objects.all():
+        new_label = _normalise_block_text(block.collections_label)
+        if new_label != block.collections_label:
+            block.collections_label = new_label
+            block.save(update_fields=["collections_label"])
 
 
 def reverse(apps, schema_editor):

--- a/cms/migrations/0083_normalize_other_block_descriptions.py
+++ b/cms/migrations/0083_normalize_other_block_descriptions.py
@@ -1,0 +1,98 @@
+"""
+Preventive normalisation for blocks that share the same template/widget shape
+as the "Our Model" bug (Textarea-edited text rendered inside a literal ``<p>``):
+
+* WideHeaderCirclesBlock.sub_heading
+* ContactFormBlock.intro_text
+* FeatureCardsBlock.card_1_text / card_2_text / card_3_text
+
+Each value is sanitised with the standard block-level allow-list and wrapped
+in ``<p>`` if it has no block-level tag, so the rendered HTML stays identical
+after the templates drop their literal ``<p>`` wrappers.
+"""
+
+import re
+
+import bleach
+from django.db import migrations
+
+_BLOCK_ALLOWED_TAGS = [
+    "a", "abbr", "acronym", "b", "blockquote", "br", "code", "del",
+    "em", "h1", "h2", "h3", "h4", "h5", "h6", "hr", "i", "img", "li",
+    "ol", "p", "pre", "s", "span", "strong", "sub", "sup", "table",
+    "tbody", "td", "th", "thead", "tr", "u", "ul",
+]
+_ALLOWED_ATTRS = {
+    "a": ["href", "title", "rel", "target"],
+    "abbr": ["title"],
+    "acronym": ["title"],
+    "img": ["src", "alt", "width", "height", "class"],
+    "td": ["colspan", "rowspan"],
+    "th": ["colspan", "rowspan", "scope"],
+    "span": ["class"],
+}
+_BLOCK_TAG_RE = re.compile(
+    r"<\s*(p|div|h[1-6]|ul|ol|li|blockquote|table|pre)\b",
+    re.IGNORECASE,
+)
+
+
+def _normalise_block_text(value):
+    if not value:
+        return value
+    cleaned = bleach.clean(
+        value,
+        tags=_BLOCK_ALLOWED_TAGS,
+        attributes=_ALLOWED_ATTRS,
+        strip=True,
+    )
+    if not _BLOCK_TAG_RE.search(cleaned):
+        cleaned = f"<p>{cleaned.strip()}</p>"
+    return cleaned
+
+
+def _normalise_field(instance, field_name):
+    current = getattr(instance, field_name)
+    new_value = _normalise_block_text(current)
+    if new_value != current:
+        setattr(instance, field_name, new_value)
+        return True
+    return False
+
+
+def forwards(apps, schema_editor):
+    WideHeaderCirclesBlock = apps.get_model("cms", "WideHeaderCirclesBlock")
+    ContactFormBlock = apps.get_model("cms", "ContactFormBlock")
+    FeatureCardsBlock = apps.get_model("cms", "FeatureCardsBlock")
+
+    for block in WideHeaderCirclesBlock.objects.all():
+        if _normalise_field(block, "sub_heading"):
+            block.save(update_fields=["sub_heading"])
+
+    for block in ContactFormBlock.objects.all():
+        if _normalise_field(block, "intro_text"):
+            block.save(update_fields=["intro_text"])
+
+    for block in FeatureCardsBlock.objects.all():
+        changed = []
+        for field in ("card_1_text", "card_2_text", "card_3_text"):
+            if _normalise_field(block, field):
+                changed.append(field)
+        if changed:
+            block.save(update_fields=changed)
+
+
+def reverse(apps, schema_editor):
+    # Stripping HTML is not safely reversible; leave normalised content in place.
+    pass
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("cms", "0082_normalize_revenue_descriptions"),
+    ]
+
+    operations = [
+        migrations.RunPython(forwards, reverse),
+    ]

--- a/cms/models.py
+++ b/cms/models.py
@@ -1927,6 +1927,10 @@ class WideHeaderCirclesBlock(BaseBlock):
     def __str__(self):
         return f"WideHeaderCirclesBlock #{self.pk}"
 
+    def save(self, *args, **kwargs):
+        self.sub_heading = sanitize_html(self.sub_heading)
+        super().save(*args, **kwargs)
+
 
 @register
 class TwoColumnContentBlock(BaseBlock):
@@ -2113,6 +2117,10 @@ class ContactFormBlock(BaseBlock):
     def __str__(self):
         return f"ContactFormBlock #{self.pk}"
 
+    def save(self, *args, **kwargs):
+        self.intro_text = sanitize_html(self.intro_text)
+        super().save(*args, **kwargs)
+
     def get_public_context(self):
         return {
             "recipients": list(self.recipients.values_list("email", flat=True))
@@ -2261,6 +2269,12 @@ class FeatureCardsBlock(BaseBlock):
 
     def __str__(self):
         return f"FeatureCardsBlock #{self.pk}"
+
+    def save(self, *args, **kwargs):
+        self.card_1_text = sanitize_html(self.card_1_text)
+        self.card_2_text = sanitize_html(self.card_2_text)
+        self.card_3_text = sanitize_html(self.card_3_text)
+        super().save(*args, **kwargs)
 
     def fallback_image_url(self, card_num):
         return self._FALLBACK_IMAGES.get(

--- a/cms/models.py
+++ b/cms/models.py
@@ -79,6 +79,38 @@ def sanitize_html(value):
     )
 
 
+INLINE_ALLOWED_TAGS = [
+    "a",
+    "abbr",
+    "b",
+    "br",
+    "em",
+    "i",
+    "s",
+    "span",
+    "strong",
+    "sub",
+    "sup",
+    "u",
+]
+
+
+def sanitize_inline_html(value):
+    """Sanitize HTML to inline-only tags (no block-level elements).
+
+    Used for fields rendered inside contexts where block-level tags such as
+    ``<p>`` or ``<div>`` would be invalid (for example inside ``<th>``).
+    """
+    if not value:
+        return value
+    return bleach.clean(
+        value,
+        tags=INLINE_ALLOWED_TAGS,
+        attributes=ALLOWED_ATTRIBUTES,
+        strip=True,
+    )
+
+
 class Category(models.Model):
     """A category for grouping news posts."""
 
@@ -1615,6 +1647,8 @@ class RevenueDistributionBlock(BaseBlock):
         return f"RevenueDistributionBlock #{self.pk}"
 
     def save(self, *args, **kwargs):
+        self.description = sanitize_html(self.description)
+        self.callout = sanitize_html(self.callout)
         super().save(*args, **kwargs)
 
     def get_public_context(self):
@@ -1733,6 +1767,11 @@ class RevenuePackageTable(models.Model):
 
     def __str__(self):
         return self.title
+
+    def save(self, *args, **kwargs):
+        # Description renders inside <th>, where block-level tags are invalid.
+        self.description = sanitize_inline_html(self.description)
+        super().save(*args, **kwargs)
 
     @property
     def header_bg_colour(self):

--- a/cms/models.py
+++ b/cms/models.py
@@ -1507,6 +1507,7 @@ class OJCModelBlock(BaseBlock):
 
     def save(self, *args, **kwargs):
         self.body = sanitize_html(self.body)
+        self.collections_label = sanitize_html(self.collections_label)
         super().save(*args, **kwargs)
 
 

--- a/cms/templates/includes/blocks/_contact_form.html
+++ b/cms/templates/includes/blocks/_contact_form.html
@@ -4,8 +4,8 @@
 <section class="team-contact" style="background-color: {{ block.bg_color }}; color: {{ block.text_color }};" aria-labelledby="contact-heading-{{ block.pk }}">
     <div class="container">
         <div class="team-contact-inner">
-            <div class="team-contact-text">
-                <p id="contact-heading-{{ block.pk }}">{{ block.intro_text }}</p>
+            <div class="team-contact-text" id="contact-heading-{{ block.pk }}">
+                {{ block.intro_text|safe }}
             </div>
             <div class="team-contact-form">
                 {% if contact_sent %}

--- a/cms/templates/includes/blocks/_feature_cards.html
+++ b/cms/templates/includes/blocks/_feature_cards.html
@@ -13,7 +13,7 @@
                              class="feature-image">
                         <div class="feature-number">{{ block.card_1_number }}</div>
                         <h3 class="feature-title" style="color: {{ block.text_color }};">{{ block.card_1_title }}</h3>
-                        <p class="feature-text" style="color: {{ block.text_color }};">{{ block.card_1_text }}</p>
+                        <div class="feature-text" style="color: {{ block.text_color }};">{{ block.card_1_text|safe }}</div>
                         {% if block.card_1_cta_text %}
                         <a href="{{ block.card_1_cta_url }}"
                            class="btn spectral-bold feature-btn feature-cta-{{ block.pk }}"
@@ -28,7 +28,7 @@
                              class="feature-image">
                         <div class="feature-number">{{ block.card_2_number }}</div>
                         <h3 class="feature-title" style="color: {{ block.text_color }};">{{ block.card_2_title }}</h3>
-                        <p class="feature-text" style="color: {{ block.text_color }};">{{ block.card_2_text }}</p>
+                        <div class="feature-text" style="color: {{ block.text_color }};">{{ block.card_2_text|safe }}</div>
                         {% if block.card_2_cta_text %}
                         <a href="{{ block.card_2_cta_url }}"
                            class="btn spectral-bold feature-btn feature-cta-{{ block.pk }}"
@@ -43,7 +43,7 @@
                              class="feature-image">
                         <div class="feature-number">{{ block.card_3_number }}</div>
                         <h3 class="feature-title" style="color: {{ block.text_color }};">{{ block.card_3_title }}</h3>
-                        <p class="feature-text" style="color: {{ block.text_color }};">{{ block.card_3_text }}</p>
+                        <div class="feature-text" style="color: {{ block.text_color }};">{{ block.card_3_text|safe }}</div>
                         {% if block.card_3_cta_text %}
                         <a href="{{ block.card_3_cta_url }}"
                            class="btn spectral-bold feature-btn feature-cta-{{ block.pk }}"

--- a/cms/templates/includes/blocks/_ojc_model.html
+++ b/cms/templates/includes/blocks/_ojc_model.html
@@ -6,7 +6,7 @@
             <h2 id="model-section-heading-{{ block.pk }}" class="spectral-bold">{{ block.heading }}</h2>
             {{ block.body|safe }}
         </div>
-        <p class="model-collections-label">{{ block.collections_label }}</p>
+        <div class="model-collections-label">{{ block.collections_label|safe }}</div>
         <div class="model-collections">
             <div class="model-collection-card">
                 <div class="model-collection-circle" style="background-color: {{ block.circle_bg_color }}; color: {{ block.circle_text_color }};">

--- a/cms/templates/includes/blocks/_revenue_distribution.html
+++ b/cms/templates/includes/blocks/_revenue_distribution.html
@@ -5,7 +5,7 @@
         <div class="model-revenue-layout">
             <div class="model-revenue-header">
                 <h2 id="model-revenue-heading-{{ block.pk }}" class="spectral-bold">{{ block.heading }}</h2>
-                <p>{{ block.description }}</p>
+                <div class="model-revenue-description">{{ block.description|safe }}</div>
             </div>
 
             <div class="model-revenue-tables">
@@ -24,12 +24,12 @@
                 {% for table in tables %}
                 <!-- {{ table.title }} -->
                 <table class="model-packages-table" aria-labelledby="table-heading-{{ table.pk }}">
-                    <caption class="sr-only">{{ table.title }} — {{ table.description }}</caption>
+                    <caption class="sr-only">{{ table.title }} — {{ table.description|striptags }}</caption>
                     <thead>
                         <tr class="package-header" style="background-color: {{ table.header_bg_colour }}; color: {{ table.text_colour }};">
                             <th scope="colgroup" colspan="{{ num_columns }}" id="table-heading-{{ table.pk }}">
                                 <strong>{{ table.title }}</strong><br>
-                                {{ table.description }}
+                                {{ table.description|safe }}
                             </th>
                         </tr>
                     </thead>

--- a/cms/templates/includes/blocks/_wide_header_circles.html
+++ b/cms/templates/includes/blocks/_wide_header_circles.html
@@ -20,7 +20,7 @@
                 {{ block.heading }}
             </h1>
             {% if block.sub_heading %}
-            <p class="about-hero-sub" style="color: {{ block.text_color }};">{{ block.sub_heading }}</p>
+            <div class="about-hero-sub" style="color: {{ block.text_color }};">{{ block.sub_heading|safe }}</div>
             {% endif %}
         </div>
     </div>

--- a/cms/tests/test_revenue_distribution_html_safety.py
+++ b/cms/tests/test_revenue_distribution_html_safety.py
@@ -1,0 +1,174 @@
+"""
+Tests for HTML safety in the RevenueDistributionBlock and its child
+RevenuePackageTable rows, plus the public render template.
+
+Covers the "Our Model" preset bug where stored ``<p>`` tags were rendered
+as escaped text (``&lt;p&gt;``) inside an outer ``<p>`` wrapper, and where
+the package-table description in the ``<th>`` cell appeared verbatim with
+escaped HTML tags.
+"""
+
+from django.template.loader import render_to_string
+from django.test import SimpleTestCase, TestCase
+
+from cms.models import (
+    RevenueDistributionBlock,
+    RevenuePackageCell,
+    RevenuePackageRow,
+    RevenuePackageTable,
+    RevenueTableColumn,
+    sanitize_inline_html,
+)
+
+
+class SanitizeInlineHtmlTests(SimpleTestCase):
+    """The inline-only sanitiser preserves inline tags and strips block ones."""
+
+    def test_allows_inline_formatting(self):
+        html = "<strong>Hello</strong> <em>world</em>"
+        self.assertEqual(sanitize_inline_html(html), html)
+
+    def test_allows_line_break(self):
+        html = "Title<br>Subtitle"
+        self.assertEqual(sanitize_inline_html(html), html)
+
+    def test_strips_paragraph_wrapper_keeping_text(self):
+        result = sanitize_inline_html("<p>Hello</p>")
+        self.assertNotIn("<p>", result)
+        self.assertNotIn("</p>", result)
+        self.assertIn("Hello", result)
+
+    def test_strips_div_wrapper_keeping_text(self):
+        result = sanitize_inline_html("<div>Hello</div>")
+        self.assertNotIn("<div>", result)
+        self.assertIn("Hello", result)
+
+    def test_strips_heading_keeping_text(self):
+        result = sanitize_inline_html("<h2>Hello</h2>")
+        self.assertNotIn("<h2>", result)
+        self.assertIn("Hello", result)
+
+    def test_strips_script(self):
+        result = sanitize_inline_html("<strong>Hi</strong><script>x</script>")
+        self.assertNotIn("<script", result)
+        self.assertIn("<strong>Hi</strong>", result)
+
+    def test_allows_link_with_href(self):
+        html = '<a href="https://example.com">link</a>'
+        self.assertEqual(sanitize_inline_html(html), html)
+
+    def test_empty_string(self):
+        self.assertEqual(sanitize_inline_html(""), "")
+
+    def test_none(self):
+        self.assertIsNone(sanitize_inline_html(None))
+
+
+class RevenueDistributionBlockSanitisationTests(TestCase):
+    """Description and callout are sanitised but keep block-level tags."""
+
+    def test_description_keeps_paragraph_strips_script(self):
+        block = RevenueDistributionBlock.objects.create(
+            description='<p>Hello</p><script>alert("x")</script>'
+        )
+        self.assertNotIn("<script", block.description)
+        self.assertIn("<p>Hello</p>", block.description)
+
+    def test_callout_keeps_paragraph_strips_script(self):
+        block = RevenueDistributionBlock.objects.create(
+            callout='<p>Note</p><iframe src="evil"></iframe>'
+        )
+        self.assertNotIn("<iframe", block.callout)
+        self.assertIn("<p>Note</p>", block.callout)
+
+
+class RevenuePackageTableSanitisationTests(TestCase):
+    """Package table description is forced to inline-only HTML on save."""
+
+    def setUp(self):
+        self.block = RevenueDistributionBlock.objects.create()
+
+    def test_block_paragraph_wrapper_is_stripped(self):
+        table = RevenuePackageTable.objects.create(
+            block=self.block,
+            title="Package A",
+            description="<p>Full support for journals.</p>",
+        )
+        self.assertNotIn("<p>", table.description)
+        self.assertNotIn("</p>", table.description)
+        self.assertIn("Full support for journals.", table.description)
+
+    def test_inline_strong_and_br_preserved(self):
+        table = RevenuePackageTable.objects.create(
+            block=self.block,
+            title="Package B",
+            description="<strong>Tier 1</strong><br>Some support",
+        )
+        self.assertIn("<strong>Tier 1</strong>", table.description)
+        self.assertIn("<br>", table.description)
+
+    def test_script_is_stripped(self):
+        table = RevenuePackageTable.objects.create(
+            block=self.block,
+            title="Package C",
+            description="<script>alert(1)</script>safe text",
+        )
+        self.assertNotIn("<script", table.description)
+        self.assertIn("safe text", table.description)
+
+
+class RevenueDistributionTemplateRenderTests(TestCase):
+    """Rendered template must not leak literal escaped HTML."""
+
+    def setUp(self):
+        self.block = RevenueDistributionBlock.objects.create(
+            description="<p>Section description with <em>emphasis</em>.</p>",
+            callout="<p>Important callout.</p>",
+        )
+        col = RevenueTableColumn.objects.create(
+            block=self.block, heading="Size", sort_order=0
+        )
+        table = RevenuePackageTable.objects.create(
+            block=self.block,
+            title="Package A (full fat)",
+            description="Partial support for journals.",
+            colour_preset="pink",
+            sort_order=0,
+        )
+        row = RevenuePackageRow.objects.create(table=table, sort_order=0)
+        RevenuePackageCell.objects.create(row=row, column=col, value="Tiny")
+
+    def render(self):
+        block = RevenueDistributionBlock.objects.get(pk=self.block.pk)
+        context = {"block": block, **block.get_public_context()}
+        return render_to_string(
+            "includes/blocks/_revenue_distribution.html", context
+        )
+
+    def test_section_description_renders_html_not_escaped(self):
+        out = self.render()
+        self.assertIn("<em>emphasis</em>", out)
+        self.assertNotIn("&lt;p&gt;", out)
+        self.assertNotIn("&lt;em&gt;", out)
+
+    def test_section_description_does_not_double_wrap_p(self):
+        out = self.render()
+        self.assertNotIn("<p><p>", out)
+        self.assertNotIn("</p></p>", out)
+
+    def test_table_description_renders_safely(self):
+        out = self.render()
+        self.assertIn("Partial support for journals.", out)
+        # No escaped HTML in the table header
+        self.assertNotIn("&lt;", out)
+
+    def test_caption_strips_html_for_screen_readers(self):
+        # Push HTML into the table description and verify the sr-only caption
+        # contains plain text only (HTML stripped via |striptags).
+        table = self.block.package_tables.first()
+        table.description = "<strong>Tier 1</strong><br>Notes"
+        table.save()
+        out = self.render()
+        # The <caption class="sr-only"> should contain plain "Tier 1Notes"
+        # with no <strong> or <br> tags.
+        self.assertIn("Package A (full fat) — Tier 1", out)

--- a/cms/tests/test_revenue_distribution_html_safety.py
+++ b/cms/tests/test_revenue_distribution_html_safety.py
@@ -12,6 +12,7 @@ from django.template.loader import render_to_string
 from django.test import SimpleTestCase, TestCase
 
 from cms.models import (
+    OJCModelBlock,
     RevenueDistributionBlock,
     RevenuePackageCell,
     RevenuePackageRow,
@@ -172,3 +173,27 @@ class RevenueDistributionTemplateRenderTests(TestCase):
         # The <caption class="sr-only"> should contain plain "Tier 1Notes"
         # with no <strong> or <br> tags.
         self.assertIn("Package A (full fat) — Tier 1", out)
+
+
+class OJCModelBlockHtmlSafetyTests(TestCase):
+    """Same bug pattern as RevenueDistribution: stored <p> tags in
+    collections_label rendered as escaped text inside an outer <p>."""
+
+    def test_collections_label_sanitised_on_save_keeps_p(self):
+        block = OJCModelBlock.objects.create(
+            collections_label="<p>We offer three.</p><script>x</script>"
+        )
+        self.assertNotIn("<script", block.collections_label)
+        self.assertIn("<p>We offer three.</p>", block.collections_label)
+
+    def test_template_does_not_double_wrap_collections_label(self):
+        block = OJCModelBlock.objects.create(
+            collections_label="<p>We offer three.</p>"
+        )
+        out = render_to_string(
+            "includes/blocks/_ojc_model.html", {"block": block}
+        )
+        self.assertNotIn("&lt;p&gt;", out)
+        self.assertNotIn("<p><p>", out)
+        self.assertNotIn("</p></p>", out)
+        self.assertIn("We offer three.", out)

--- a/cms/tests/test_revenue_distribution_html_safety.py
+++ b/cms/tests/test_revenue_distribution_html_safety.py
@@ -12,12 +12,15 @@ from django.template.loader import render_to_string
 from django.test import SimpleTestCase, TestCase
 
 from cms.models import (
+    ContactFormBlock,
+    FeatureCardsBlock,
     OJCModelBlock,
     RevenueDistributionBlock,
     RevenuePackageCell,
     RevenuePackageRow,
     RevenuePackageTable,
     RevenueTableColumn,
+    WideHeaderCirclesBlock,
     sanitize_inline_html,
 )
 
@@ -197,3 +200,86 @@ class OJCModelBlockHtmlSafetyTests(TestCase):
         self.assertNotIn("<p><p>", out)
         self.assertNotIn("</p></p>", out)
         self.assertIn("We offer three.", out)
+
+
+class WideHeaderCirclesBlockHtmlSafetyTests(TestCase):
+    """Preventive hardening for WideHeaderCirclesBlock.sub_heading."""
+
+    def test_sub_heading_sanitised_on_save_keeps_p(self):
+        block = WideHeaderCirclesBlock.objects.create(
+            sub_heading="<p>Mission text.</p><script>x</script>"
+        )
+        self.assertNotIn("<script", block.sub_heading)
+        self.assertIn("<p>Mission text.</p>", block.sub_heading)
+
+    def test_template_does_not_double_wrap_sub_heading(self):
+        block = WideHeaderCirclesBlock.objects.create(
+            sub_heading="<p>Mission text.</p>"
+        )
+        out = render_to_string(
+            "includes/blocks/_wide_header_circles.html", {"block": block}
+        )
+        self.assertNotIn("&lt;p&gt;", out)
+        self.assertNotIn("<p><p>", out)
+        self.assertNotIn("</p></p>", out)
+        self.assertIn("Mission text.", out)
+
+
+class ContactFormBlockHtmlSafetyTests(TestCase):
+    """Preventive hardening for ContactFormBlock.intro_text."""
+
+    def test_intro_text_sanitised_on_save_keeps_p(self):
+        block = ContactFormBlock.objects.create(
+            intro_text="<p>Contact us.</p><script>x</script>"
+        )
+        self.assertNotIn("<script", block.intro_text)
+        self.assertIn("<p>Contact us.</p>", block.intro_text)
+
+    def test_template_does_not_double_wrap_intro_text(self):
+        block = ContactFormBlock.objects.create(
+            intro_text="<p>Contact us.</p>"
+        )
+        out = render_to_string(
+            "includes/blocks/_contact_form.html", {"block": block}
+        )
+        self.assertNotIn("&lt;p&gt;", out)
+        self.assertNotIn("<p><p>", out)
+        self.assertNotIn("</p></p>", out)
+        self.assertIn("Contact us.", out)
+
+
+class FeatureCardsBlockHtmlSafetyTests(TestCase):
+    """Preventive hardening for FeatureCardsBlock card_*_text fields."""
+
+    def test_card_texts_sanitised_on_save_keep_p(self):
+        block = FeatureCardsBlock.objects.create(
+            card_1_text="<p>One.</p><script>a</script>",
+            card_2_text="<p>Two.</p><iframe></iframe>",
+            card_3_text="<p>Three.</p><style>x</style>",
+        )
+        for value in (
+            block.card_1_text,
+            block.card_2_text,
+            block.card_3_text,
+        ):
+            self.assertNotIn("<script", value)
+            self.assertNotIn("<iframe", value)
+            self.assertNotIn("<style", value)
+        self.assertIn("<p>One.</p>", block.card_1_text)
+        self.assertIn("<p>Two.</p>", block.card_2_text)
+        self.assertIn("<p>Three.</p>", block.card_3_text)
+
+    def test_template_does_not_double_wrap_card_texts(self):
+        block = FeatureCardsBlock.objects.create(
+            card_1_text="<p>One.</p>",
+            card_2_text="<p>Two.</p>",
+            card_3_text="<p>Three.</p>",
+        )
+        out = render_to_string(
+            "includes/blocks/_feature_cards.html", {"block": block}
+        )
+        self.assertNotIn("&lt;p&gt;", out)
+        self.assertNotIn("<p><p>", out)
+        self.assertNotIn("</p></p>", out)
+        for word in ("One.", "Two.", "Three."):
+            self.assertIn(word, out)


### PR DESCRIPTION
## Summary

The "Our Model" preset rendered stored HTML as escaped text — `<p>&lt;p&gt;…&lt;/p&gt;</p>` for the section/section-callout descriptions and `&lt;p&gt;…&lt;/p&gt;` inside package-table `<th>` cells. Two distinct cases:

1. **Double-`<p>` wrap**: template wrapped content in literal `<p>` while the stored value already contained `<p>`. Adding `|safe` alone would have produced invalid `<p><p>…</p></p>`, so the template now uses a `<div>` wrapper plus `|safe`.
2. **Escaped HTML in `<th>`**: cell rendered the description with no filter; block-level tags such as `<p>` are also invalid inside a `<th>`, so the field is now sanitised down to inline-only HTML on save.

Each affected model gained a `save()` override that runs `sanitize_html()` (or a new inline-only `sanitize_inline_html()`), and form widgets switched from `Textarea` to `TinyMCE` for consistency with the other rich-text fields. Two data migrations normalise legacy rows so existing pages render correctly without manual editor passes.

After fixing the user-reported cases, the same template/widget shape was preventively hardened on three other blocks (`WideHeaderCirclesBlock`, `ContactFormBlock`, `FeatureCardsBlock`) — currently safe but vulnerable to the same paste-of-HTML trigger.

### Commits
- `f54f0f6` revenue distribution fix (sanitiser, save methods, template, migration, tests)
- `193a9cd` TinyMCE upgrade for revenue description/callout/package fields
- `74fa207` OJC `collections_label` fix
- `a65e5a1` preventive hardening for `WideHeaderCircles.sub_heading`, `ContactForm.intro_text`, `FeatureCards.card_*_text`

## Test plan

- [x] Unit tests: 26 new tests in `cms/tests/test_revenue_distribution_html_safety.py` covering the inline sanitiser, per-block save sanitisation, template rendering safety, and accessibility caption stripping
- [x] Full cms suite: 450 tests, all green
- [x] Pre-commit (`ruff-format`, `ruff`, hooked test runner): all green
- [x] Apply migrations on the live DB (`uv run ./manage.py migrate`) to run `0082` and `0083` against existing rows
- [x] Browse the "Our Model" preset and confirm the section description, package-table descriptions, OJC `collections_label`, and callout render as normal HTML with no `&lt;p&gt;` artefacts and no nested `<p><p>…</p></p>`
- [x] Open the block editor for each affected block, edit a description through TinyMCE, save, and confirm round-trip is clean
- [x] Spot-check About Us, Our Team, and Landing pages to confirm the preventive hardening did not change rendered output for plain-text values