### PR TITLE
feat(public): landing safe filters and collection download links

### DIFF
--- a/cms/templates/includes/blocks/_landing_hero.html
+++ b/cms/templates/includes/blocks/_landing_hero.html
@@ -14,10 +14,10 @@
         <div class="container">
             <div class="landing-hero-content" style="border-left-color: {{ block.text_color }};">
                 <h1 class="landing-hero-heading spectral-bold" style="color: {{ block.text_color }};">
-                    {{ block.heading }}
+                    {{ block.heading|safe }}
                 </h1>
                 <p class="landing-hero-sub" style="color: {{ block.text_color }};">
-                    {{ block.sub_heading }}
+                    {{ block.sub_heading|safe }}
                 </p>
                 {% if block.cta_text %}
                 <style>

--- a/cms/templates/includes/blocks/_landing_stats.html
+++ b/cms/templates/includes/blocks/_landing_stats.html
@@ -23,7 +23,7 @@
                     <span class="landing-stats-target" style="color: {{ block.text_color }};">raised of {{ block.fundraising_target_display }}</span>
                 </div>
                 <p class="landing-stats-desc" style="color: {{ block.text_color }};">
-                    {{ block.description }}
+                    {{ block.description|safe }}
                 </p>
                 <div class="landing-stats-buttons">
                     {% if block.button_1_text %}

--- a/journals/admin.py
+++ b/journals/admin.py
@@ -177,6 +177,7 @@ class JournalAdmin(admin.ModelAdmin):
                     "journal_owner",
                     "platform",
                     "description",
+                    "cover",
                 )
             },
         ),

--- a/journals/templates/public/public_search.html
+++ b/journals/templates/public/public_search.html
@@ -21,7 +21,7 @@
   <div class="cata-container">
     <p class="cata-search__intro">
       Explore our collection of open access, community-led academic journals,
-      or download the full list in one click.
+      or download a full list of all journals in each collection
     </p>
 
     <form method="get" action="{% url 'journals:public_search' %}" class="cata-search__form">
@@ -40,7 +40,7 @@
               class="cata-filters-toggle"
               onclick="toggleFilters()"
               id="filters-toggle-btn">
-        ⚙ Filters
+        <img src="/static/img/favicon.ico" alt="Description of the icon" width="12" height="12"> Filters
         {% if current_filters.subject or current_filters.publisher or current_filters.in_doaj == 'yes' or current_filters.language %}
         (active)
         {% endif %}
@@ -104,13 +104,10 @@
       </div>
     </form>
 
-    <p class="cata-search__download-text">
-      Or download the full collection, copy here
-    </p>
     <div class="cata-search__download-btns">
-      <a href="#" class="cata-download-btn">Download Journal List 1</a>
-      <a href="#" class="cata-download-btn">Download Journal List 2</a>
-      <a href="#" class="cata-download-btn">Download Journal List 3</a>
+      <a href="https://www.openjournalscollective.org/files/2026-ojc-collection-multidisciplinary.xlsx" class="cata-download-btn">Multidisciplinary Collection</a>
+      <a href="https://www.openjournalscollective.org/files/2026-ojc-collections-ahss.xlsx" class="cata-download-btn">Arts, Humanities & Social Sciences Collection</a>
+      <a href="https://www.openjournalscollective.org/files/2026-ojc-collections-stem.xlsx" class="cata-download-btn">STEM Collection</a>
     </div>
   </div>
 </section>


### PR DESCRIPTION
Replicate changes applied directly on the server:
- Render landing hero heading/sub-heading and stats description with |safe so embedded markup displays
- Add the cover field to the Journal admin Basic Information fieldset
- Update the catalogue search intro copy, swap the filters glyph for a favicon image, and point the download buttons at the 2026 OJC collection spreadsheets